### PR TITLE
GoReleaser flag `--rm-dist` has been deprecated

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -29,6 +29,6 @@ jobs:
         uses: 'goreleaser/goreleaser-action@v4.2.0'
         with:
           version: 'latest'
-          args: 'release --rm-dist'
+          args: 'release --clean'
         env:
           GITHUB_TOKEN: '${{ secrets.GITHUB_TOKEN }}'


### PR DESCRIPTION
Ref: https://goreleaser.com/deprecations/#-rm-dist